### PR TITLE
Displays the current direnv state in settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins =
+platformPlugins = org.jetbrains.plugins.go
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/src/main/java/systems/fehn/intellijdirenv/extensions/DirenvGoRunConfigurationExtension.java
+++ b/src/main/java/systems/fehn/intellijdirenv/extensions/DirenvGoRunConfigurationExtension.java
@@ -1,0 +1,35 @@
+package systems.fehn.intellijdirenv.extensions;
+
+import com.goide.execution.GoRunConfigurationBase;
+import com.goide.execution.GoRunningState;
+import com.goide.execution.extension.GoRunConfigurationExtension;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.RunnerSettings;
+import com.intellij.execution.target.TargetedCommandLineBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import systems.fehn.intellijdirenv.settings.DirenvSettingsState;
+
+import java.util.Map;
+
+public class DirenvGoRunConfigurationExtension extends GoRunConfigurationExtension {
+    @Override
+    public boolean isApplicableFor(@NotNull GoRunConfigurationBase<?> configuration) {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabledFor(@NotNull GoRunConfigurationBase<?> applicableConfiguration, @Nullable RunnerSettings runnerSettings) {
+        return true;
+    }
+
+    @Override
+    protected void patchCommandLine(@NotNull GoRunConfigurationBase<?> configuration, @Nullable RunnerSettings runnerSettings, @NotNull TargetedCommandLineBuilder cmdLine, @NotNull String runnerId, @NotNull GoRunningState<? extends GoRunConfigurationBase<?>> state, GoRunningState.CommandLineType commandLineType) throws ExecutionException {
+        DirenvSettingsState settings = DirenvSettingsState.getInstance();
+
+        Map<String, String> direnvVars = settings.getDirenvVars();
+        for (Map.Entry<String, String> entry : direnvVars.entrySet()) {
+            cmdLine.addEnvironmentVariable(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsComponent.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsComponent.java
@@ -2,21 +2,39 @@ package systems.fehn.intellijdirenv.settings;
 
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.table.JBTable;
 import com.intellij.util.ui.FormBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.util.Map;
 
 public class DirenvSettingsComponent {
     private final JPanel mainPanel;
     private final TextFieldWithBrowseButton direnvPath = new TextFieldWithBrowseButton();
+    private final JBTable envStateTable;
 
     public DirenvSettingsComponent() {
         direnvPath.addBrowseFolderListener( "Direnv Path", "Path to the direnv file", null,
                 FileChooserDescriptorFactory.createSingleFileDescriptor());
+
+        DefaultTableModel tableModel = new DefaultTableModel(new String[]{"Name", "Value"}, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+
+        envStateTable = new JBTable(tableModel);
+        JScrollPane scrollPane = new JBScrollPane(envStateTable);
+        envStateTable.setFillsViewportHeight(true);
+
         mainPanel = FormBuilder
                 .createFormBuilder()
                 .addLabeledComponent(new JLabel("DirenvPath: "), direnvPath, 1, false)
+                .addComponent(scrollPane)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -36,5 +54,14 @@ public class DirenvSettingsComponent {
 
     public void setDirenvPath(@NotNull String path) {
         direnvPath.setText(path);
+    }
+
+    public void updateDirenvVars(Map<String, String> direnvVars) {
+        envStateTable.removeAll();
+        DefaultTableModel tableModel = (DefaultTableModel)envStateTable.getModel();
+
+        for (Map.Entry<String, String> vars : direnvVars.entrySet()) {
+            tableModel.addRow(new String[]{vars.getKey(), vars.getValue()});
+        }
     }
 }

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsConfigurable.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsConfigurable.java
@@ -23,7 +23,11 @@ public class DirenvSettingsConfigurable implements Configurable {
 
     @Override
     public @Nullable JComponent createComponent() {
+        DirenvSettingsState settings = DirenvSettingsState.getInstance();
+
         direnvSettingsComponent = new DirenvSettingsComponent();
+        direnvSettingsComponent.updateDirenvVars(settings.getDirenvVars());
+
         return direnvSettingsComponent.getPanel();
     }
 

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsState.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsState.java
@@ -8,16 +8,19 @@ import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @State(
         name = "systems.fehn.intellijdirenv.settings.DirenvSettingsState",
         storages = @Storage("DirenvSettings.xml")
 )
 public class DirenvSettingsState implements PersistentStateComponent<DirenvSettingsState> {
     public String direnvSettingsPath = "";
+    private Map<String, String> direnvVars = new HashMap<>();
 
     public static DirenvSettingsState getInstance() {
-        DirenvSettingsState instance = ApplicationManager.getApplication().getService(DirenvSettingsState.class);
-        return instance;
+        return ApplicationManager.getApplication().getService(DirenvSettingsState.class);
     }
 
     @Override
@@ -28,5 +31,13 @@ public class DirenvSettingsState implements PersistentStateComponent<DirenvSetti
     @Override
     public void loadState(@NotNull DirenvSettingsState state) {
         XmlSerializerUtil.copyBean(state, this);
+    }
+
+    public Map<String, String> getDirenvVars() {
+        return this.direnvVars;
+    }
+
+    public void setDirenvVars(Map<String, String> direnvVars) {
+        this.direnvVars = direnvVars;
     }
 }

--- a/src/main/kotlin/systems/fehn/intellijdirenv/services/EnvironmentService.kt
+++ b/src/main/kotlin/systems/fehn/intellijdirenv/services/EnvironmentService.kt
@@ -1,13 +1,20 @@
 package systems.fehn.intellijdirenv.services
 
 import systems.fehn.intellijdirenv.MyBundle
+import systems.fehn.intellijdirenv.settings.DirenvSettingsState
 
 class EnvironmentService {
     fun unsetVariable(name: String) {
+        val appSettings = DirenvSettingsState.getInstance()
+
+        appSettings.direnvVars.remove(name)
         modifiableEnvironment.remove(name)
     }
 
     fun setVariable(name: String, value: String) {
+        val appSettings = DirenvSettingsState.getInstance()
+
+        appSettings.direnvVars[name] = value
         modifiableEnvironment[name] = value
     }
 

--- a/src/main/resources/META-INF/direnv-go.xml
+++ b/src/main/resources/META-INF/direnv-go.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.goide">
+    <runConfigurationExtension implementation="systems.fehn.intellijdirenv.extensions.DirenvGoRunConfigurationExtension"
+                               id="direnvGo"/>
+  </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,4 +35,6 @@
                     relative-to-action="SynchronizeCurrentFile"/>
     </action>
   </actions>
+
+  <depends optional="true" config-file="direnv-go.xml">org.jetbrains.plugins.go</depends>
 </idea-plugin>


### PR DESCRIPTION
Useful for debugging what the current state of the direnv environment variables are. Shows the current state in settings dialog. Builds on https://github.com/fehnomenal/intellij-direnv/pull/25 but wanted to keep them separate for simpler PR reviewing.

Updated this PR with better GoLand support. It wouldn't update the env vars after the initial import, this injects them directly into the run config.
