### PR TITLE
Remove `pluginUntilBuild`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Remove upper version bound
+
 ## [0.2.9] - 2024-01-26
 
 - Apply changes from [template v1.11.3](https://github.com/JetBrains/intellij-platform-plugin-template/releases/tag/v1.11.3)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 0.2.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 299.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
direnv is not compatible with the latest EAP builds:

<img width="1285" alt="Screenshot 2024-07-04 at 15 11 29" src="https://github.com/fehnomenal/intellij-direnv/assets/17706737/4d8e381f-4517-4bf5-82ea-1d5feb8ab5b7">

This PR removes `pluginUntilBuild` from `gradle.properties`, which allows installing the plugin with the latest EAP builds.

