### PR TITLE
feat(settings): added auto-detect direnv program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.qodana/
 /build/
 /.envrc
+/.direnv/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,6 +130,12 @@ tasks {
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+        val versions = properties("pluginVersion").map {
+            val element = it.split('-').getOrNull(1)?.split('.')?.first()
+            listOf(element ?: "default")
+        }
+
+        channels.set(versions)
     }
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,10 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706006310,
-        "narHash": "sha256-nDPz0fj0IFcDhSTlXBU2aixcnGs2Jm4Zcuoj0QtmiXQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b43bb235efeab5324c5e486882ef46749188eee2",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-1mEKHp4m9brvfQ0rjCca8P1WHpymK3TOr3v34ydv9bs=",
+        "path": "/nix/store/hkv63lvykwr520xf8yv2gcw3s78fjfpd-source",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,6 @@
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in
     {
-      devShell.x86_64-linux = pkgs.mkShell {
-        buildInputs = [
-          pkgs.openjdk17
-        ];
-      };
+      devShell.x86_64-linux = import ./shell.nix { inherit pkgs; };
     };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell
+{
+  nativeBuildInputs = with pkgs; [
+    jetbrains.jdk
+    gradle
+  ];
+}
+


### PR DESCRIPTION
Hi, I want to add a simple new thing: auto-detect direnv program.
On startup plugin can detect direnv program in currect PATH variable. If plugin can't find file, then return default empty string(previous version of default value in direnvSettingPath).
Also I changed:
- exported nix-shell configuration to shell.nix file (it's helpful for non-flake users)
- changed `channels` option from publishPlugin, because plugin SDK change `channels` option to `val`