### PR TITLE
fixes deprecation warning that crashes plugin

### DIFF
--- a/src/main/kotlin/systems/fehn/intellijdirenv/DirenvImportAction.kt
+++ b/src/main/kotlin/systems/fehn/intellijdirenv/DirenvImportAction.kt
@@ -1,13 +1,13 @@
 package systems.fehn.intellijdirenv
 
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.ActionPlaces
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.*
 import systems.fehn.intellijdirenv.services.DirenvProjectService
 
 class DirenvImportAction : AnAction(MyBundle.message("importDirenvAction")) {
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
     override fun update(e: AnActionEvent) {
         if (e.project == null) {
             e.presentation.isEnabledAndVisible = false


### PR DESCRIPTION
fixes the following error message that crashes the plugin, at least on WebStorm 2024.2: 

com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'systems.fehn.intellijdirenv.DirenvImportAction' must override `getActionUpdateThread()` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: systems.fehn.intellijdirenv]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
	at com.intellij.diagnostic.PluginException.reportDeprecatedUsage(PluginException.java:125)
	at com.intellij.openapi.actionSystem.ActionUpdateThreadAware.getActionUpdateThread(ActionUpdateThreadAware.java:21)
	at com.intellij.openapi.actionSystem.AnAction.getActionUpdateThread(AnAction.java:201)