### PR TITLE
Add an option to search for .envrc in parent directories.

### DIFF
--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsComponent.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsComponent.java
@@ -13,6 +13,7 @@ public class DirenvSettingsComponent {
     private final TextFieldWithBrowseButton direnvPath = new TextFieldWithBrowseButton();
     private final JBCheckBox direnvImportOnStartup = new JBCheckBox("Automatically import any .envrc in the project root when the project is opened.");
     private final JBCheckBox direnvImportEveryExecution = new JBCheckBox("Automatically import any .envrc in the project root before every run/debug");
+    private final JBCheckBox direnvImportRecursive = new JBCheckBox("If not found, search for .envrc in parent directories.");
 
 
     public DirenvSettingsComponent() {
@@ -23,6 +24,7 @@ public class DirenvSettingsComponent {
                 .addLabeledComponent(new JLabel("DirenvPath: "), direnvPath, 1, false)
                 .addComponent(direnvImportOnStartup, 1)
                 .addComponent(direnvImportEveryExecution, 1)
+                .addComponent(direnvImportRecursive, 1)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -58,5 +60,13 @@ public class DirenvSettingsComponent {
 
     public void setDirenvImportEveryExecution(boolean newStatus) {
         direnvImportEveryExecution.setSelected(newStatus);
+    }
+
+    public boolean getDirenvImportRecursive() {
+        return direnvImportRecursive.isSelected();
+    }
+
+    public void setDirenvImportRecursive(boolean newStatus) {
+        direnvImportRecursive.setSelected(newStatus);
     }
 }

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsConfigurable.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsConfigurable.java
@@ -31,7 +31,8 @@ public class DirenvSettingsConfigurable implements Configurable {
         DirenvSettingsState settings = DirenvSettingsState.getInstance();
         return !direnvSettingsComponent.getDirenvPath().equals(settings.direnvSettingsPath) ||
                 direnvSettingsComponent.getDirenvImportOnStartup() != settings.direnvSettingsImportOnStartup ||
-                direnvSettingsComponent.getDirenvImportEveryExecution() != settings.direnvSettingsImportEveryExecution;
+                direnvSettingsComponent.getDirenvImportEveryExecution() != settings.direnvSettingsImportEveryExecution ||
+                direnvSettingsComponent.getDirenvImportRecursive() != settings.direnvSettingsImportRecursive;
     }
 
     @Override
@@ -40,6 +41,7 @@ public class DirenvSettingsConfigurable implements Configurable {
         settings.direnvSettingsPath = direnvSettingsComponent.getDirenvPath();
         settings.direnvSettingsImportOnStartup = direnvSettingsComponent.getDirenvImportOnStartup();
         settings.direnvSettingsImportEveryExecution = direnvSettingsComponent.getDirenvImportEveryExecution();
+        settings.direnvSettingsImportRecursive = direnvSettingsComponent.getDirenvImportRecursive();
     }
 
     @Override
@@ -48,6 +50,7 @@ public class DirenvSettingsConfigurable implements Configurable {
         direnvSettingsComponent.setDirenvPath(settings.direnvSettingsPath);
         direnvSettingsComponent.setDirenvImportOnStartup(settings.direnvSettingsImportOnStartup);
         direnvSettingsComponent.setDirenvImportEveryExecution(settings.direnvSettingsImportEveryExecution);
+        direnvSettingsComponent.setDirenvImportRecursive(settings.direnvSettingsImportRecursive);
     }
 
     @Override

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsState.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsState.java
@@ -16,6 +16,7 @@ public class DirenvSettingsState implements PersistentStateComponent<DirenvSetti
     public String direnvSettingsPath = "";
     public Boolean direnvSettingsImportOnStartup = false;
     public Boolean direnvSettingsImportEveryExecution = false;
+    public Boolean direnvSettingsImportRecursive = false;
 
     public static DirenvSettingsState getInstance() {
         return ApplicationManager.getApplication().getService(DirenvSettingsState.class);

--- a/src/main/kotlin/systems/fehn/intellijdirenv/StartupActivity.kt
+++ b/src/main/kotlin/systems/fehn/intellijdirenv/StartupActivity.kt
@@ -32,7 +32,7 @@ class MyStartupActivity : StartupActivity, DumbAware {
         val notification = notificationGroup
             .createNotification(
                 MyBundle.message("envrcFileFound"),
-                "",
+                it.path,
                 NotificationType.INFORMATION,
             )
             .addAction(


### PR DESCRIPTION
As far as I understand, this is default behavior of direnv anyway so should be logical to have this in the plugin.
I added a settings entry which defaults to false as well.
![image](https://github.com/user-attachments/assets/dadb5c3b-d36a-48a8-bcf9-57f4f3a38322)

Also notification ".envrc found" now includes the path of the file
![image](https://github.com/user-attachments/assets/4842dc4a-627b-49af-9eb5-510e26c14f08)


Tested on a setup like described in #64 

Also tested on a a project with no .envrc anywhere in the parent directories (the plugin is then looking up everything until it reaches /). Nothing crashes, this in the logs:

```
2024-10-16 16:02:56,528 [   9977]  FINER - #systems.fehn.intellijdirenv.services.DirenvProjectService - Scanning /home/dshatz/dev/test-no-envrc directory for .envrc
2024-10-16 16:02:56,529 [   9978]  FINER - #systems.fehn.intellijdirenv.services.DirenvProjectService - Scanning /home/dshatz/dev directory for .envrc
2024-10-16 16:02:56,533 [   9982]  FINER - #systems.fehn.intellijdirenv.services.DirenvProjectService - Scanning /home/dshatz directory for .envrc
2024-10-16 16:02:56,561 [  10010]  FINER - #systems.fehn.intellijdirenv.services.DirenvProjectService - Scanning /home directory for .envrc
2024-10-16 16:02:56,567 [  10016]  FINER - #systems.fehn.intellijdirenv.services.DirenvProjectService - Scanning / directory for .envrc
2024-10-16 16:02:56,574 [  10023]  FINER - #systems.fehn.intellijdirenv.services.DirenvProjectService - Project test-no-envrc contains no .envrc file

```
