### PR TITLE
Fix output retrieval during Direnv import

### DIFF
--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsComponent.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsComponent.java
@@ -7,22 +7,32 @@ import com.intellij.util.ui.FormBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 
 public class DirenvSettingsComponent {
     private final JPanel mainPanel;
     private final TextFieldWithBrowseButton direnvPath = new TextFieldWithBrowseButton();
+    private final JSlider direnvTimeout = new JSlider(0, 240);
+    private final JLabel direnvTiemoutLabel = new JLabel();
     private final JBCheckBox direnvImportOnStartup = new JBCheckBox("Automatically import any .envrc in the project root when the project is opened.");
     private final JBCheckBox direnvImportEveryExecution = new JBCheckBox("Automatically import any .envrc in the project root before every run/debug");
-
 
     public DirenvSettingsComponent() {
         direnvPath.addBrowseFolderListener( "Direnv Path", "Path to the direnv file", null,
                 FileChooserDescriptorFactory.createSingleFileDescriptor());
+        direnvTimeout.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                direnvTiemoutLabel.setText("Direnv execution timeout (seconds): " + direnvTimeout.getValue());
+            }
+        });
         mainPanel = FormBuilder
                 .createFormBuilder()
                 .addLabeledComponent(new JLabel("DirenvPath: "), direnvPath, 1, false)
                 .addComponent(direnvImportOnStartup, 1)
                 .addComponent(direnvImportEveryExecution, 1)
+                .addLabeledComponent(direnvTiemoutLabel, direnvTimeout, 1, false)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -58,5 +68,13 @@ public class DirenvSettingsComponent {
 
     public void setDirenvImportEveryExecution(boolean newStatus) {
         direnvImportEveryExecution.setSelected(newStatus);
+    }
+
+    public int getDirenvTimeout() {
+        return direnvTimeout.getValue();
+    }
+
+    public void setDirenvTimeout(int timeoutInSeconds) {
+        direnvTimeout.setValue(timeoutInSeconds);
     }
 }

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsConfigurable.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsConfigurable.java
@@ -31,7 +31,8 @@ public class DirenvSettingsConfigurable implements Configurable {
         DirenvSettingsState settings = DirenvSettingsState.getInstance();
         return !direnvSettingsComponent.getDirenvPath().equals(settings.direnvSettingsPath) ||
                 direnvSettingsComponent.getDirenvImportOnStartup() != settings.direnvSettingsImportOnStartup ||
-                direnvSettingsComponent.getDirenvImportEveryExecution() != settings.direnvSettingsImportEveryExecution;
+                direnvSettingsComponent.getDirenvImportEveryExecution() != settings.direnvSettingsImportEveryExecution ||
+                direnvSettingsComponent.getDirenvTimeout() != settings.direnvTimeout;
     }
 
     @Override
@@ -40,6 +41,7 @@ public class DirenvSettingsConfigurable implements Configurable {
         settings.direnvSettingsPath = direnvSettingsComponent.getDirenvPath();
         settings.direnvSettingsImportOnStartup = direnvSettingsComponent.getDirenvImportOnStartup();
         settings.direnvSettingsImportEveryExecution = direnvSettingsComponent.getDirenvImportEveryExecution();
+        settings.direnvTimeout = direnvSettingsComponent.getDirenvTimeout();
     }
 
     @Override
@@ -48,6 +50,7 @@ public class DirenvSettingsConfigurable implements Configurable {
         direnvSettingsComponent.setDirenvPath(settings.direnvSettingsPath);
         direnvSettingsComponent.setDirenvImportOnStartup(settings.direnvSettingsImportOnStartup);
         direnvSettingsComponent.setDirenvImportEveryExecution(settings.direnvSettingsImportEveryExecution);
+        direnvSettingsComponent.setDirenvTimeout(settings.direnvTimeout);
     }
 
     @Override

--- a/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsState.java
+++ b/src/main/java/systems/fehn/intellijdirenv/settings/DirenvSettingsState.java
@@ -16,6 +16,7 @@ public class DirenvSettingsState implements PersistentStateComponent<DirenvSetti
     public String direnvSettingsPath = "";
     public Boolean direnvSettingsImportOnStartup = false;
     public Boolean direnvSettingsImportEveryExecution = false;
+    public Integer direnvTimeout = 15;
 
     public static DirenvSettingsState getInstance() {
         return ApplicationManager.getApplication().getService(DirenvSettingsState.class);

--- a/src/main/kotlin/systems/fehn/intellijdirenv/services/DirenvProjectService.kt
+++ b/src/main/kotlin/systems/fehn/intellijdirenv/services/DirenvProjectService.kt
@@ -18,6 +18,8 @@ import systems.fehn.intellijdirenv.MyBundle
 import systems.fehn.intellijdirenv.notificationGroup
 import systems.fehn.intellijdirenv.settings.DirenvSettingsState
 import systems.fehn.intellijdirenv.switchNull
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
 
 @Service(Service.Level.PROJECT)
 class DirenvProjectService(private val project: Project) {
@@ -42,12 +44,20 @@ class DirenvProjectService(private val project: Project) {
     fun importDirenv(envrcFile: VirtualFile, notifyNoChange: Boolean = true) {
         val process = executeDirenv(envrcFile, "export", "json")
 
-        if (process.waitFor() != 0) {
-            handleDirenvError(process, envrcFile)
+        val output = process.inputStream.readAllBytes().toString(StandardCharsets.UTF_8)
+
+        val timoutInSeconds = DirenvSettingsState.getInstance().direnvTimeout
+
+        if (!process.waitFor(timoutInSeconds!!.toLong(), TimeUnit.SECONDS)) {
+            handleTimeout(envrcFile)
             return
         }
 
-        jsonFactory.createParser(process.inputStream).use { parser ->
+        if (process.exitValue() != 0) {
+            handleDirenvError(process, envrcFile)
+        }
+
+        jsonFactory.createParser(output).use { parser ->
 
             try {
                 val didWork = handleDirenvOutput(parser)
@@ -91,7 +101,7 @@ class DirenvProjectService(private val project: Project) {
                 }
 
                 didWork = true
-                logger.trace { "Set variable ${parser.currentName} to ${parser.valueAsString}" }
+                logger.trace("Set variable ${parser.currentName} to ${parser.valueAsString}")
             }
         }
 
@@ -99,7 +109,7 @@ class DirenvProjectService(private val project: Project) {
     }
 
     private fun handleDirenvError(process: Process, envrcFile: VirtualFile) {
-        val error = process.errorStream.bufferedReader().readText()
+        val error = process.errorStream.readAllBytes().toString(StandardCharsets.UTF_8)
 
         val notification = if (error.contains(" is blocked")) {
             notificationGroup
@@ -128,6 +138,23 @@ class DirenvProjectService(private val project: Project) {
         }
 
         notification
+            .addAction(
+                NotificationAction.create(MyBundle.message("openEnvrc")) { _, it ->
+                    it.hideBalloon()
+
+                    FileEditorManager.getInstance(project).openFile(envrcFile, true, true)
+                },
+            )
+            .notify(project)
+    }
+
+    private fun handleTimeout(envrcFile: VirtualFile) {
+        notificationGroup
+            .createNotification(
+                MyBundle.message("envrcTimeout"),
+                "",
+                NotificationType.WARNING,
+            )
             .addAction(
                 NotificationAction.create(MyBundle.message("openEnvrc")) { _, it ->
                     it.hideBalloon()

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -12,3 +12,4 @@ envrcFileFound=.envrc file found
 noTopLevelEnvrcFileFound=No .envrc in project dir found
 executedSuccessfully=Direnv import finished
 alreadyUpToDate=Direnv was already up-to-date
+envrcTimeout=Timeout reached during direnv execution


### PR DESCRIPTION
In my setup the IDE always hanged forever when importing a direnv. The reason for this was that `process.waitFor() != 0` doesn't work anymore as direnv only terminates after its output has been read (but the direnv output seems correct). Therefore, this line waited forever as the stdout would only have been read after this.

This PR changes the implementation to read the stdout first until the EOF and then waits for termination of the proccess with a configurable timeout, so that the IDE does not hang forever (as it does right now).

The built plugin is here (for anyone who wants to try it):
[Direnv integration-0.2.10.zip](https://github.com/user-attachments/files/18382479/Direnv.integration-0.2.10.zip)
You can install it manually in the plugin settings after uninstalling the old version.

Tries to fix #11